### PR TITLE
Update service definition for getTimeEntries

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -953,11 +953,6 @@
                     "location": "query",
                     "description": "End date (must be ISO 8601 date and time string)",
                     "type": "string"
-                },
-                "at": {
-                    "location": "query",
-                    "description": "Last modified date (must be ISO 8601 date and time string)",
-                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
- Default values for start_date and end_date currently break the call for an open start or end date
- ~~in addition we can use `at`for the calback to limit the entries by last modify date (see https://github.com/toggl/toggl_api_docs/issues/114 for that)~~
