### PR TITLE
pid is not required in UpdateTimeEntry()

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -890,7 +890,7 @@
                         },
                         "pid": {
                             "type": "integer",
-                            "required": true,
+                            "required": false,
                             "description": "pid: project ID (integer, not required)"
                         },
                         "tid": {


### PR DESCRIPTION
The pid is not required, so it should not be required in the service definition, otherwise this will throw errors, when trying to update a time entry without project.
