### PR TITLE
Added GetProjectTasks in services api description

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -227,6 +227,19 @@
                 }
             }
         },
+        "GetProjectTasks": {
+            "httpMethod": "GET",
+            "uri": "projects/{id}/tasks",
+            "summary": "Get Project tasks",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Project ID"
+                }
+            }
+        },
         "UpdateProject": {
             "httpMethod": "PUT",
             "uri": "projects/{id}",


### PR DESCRIPTION
I added guzzle service description for /projects/{id}/tasks api, which was missing