### PR TITLE
Adds support for GetCurrentTimeEntry

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -962,6 +962,11 @@
                 }
             }
         },
+        "GetCurrentTimeEntry": {
+            "httpMethod": "GET",
+            "uri": "time_entries/current",
+            "summary": "Get Current Time Entry"
+        },
         "UpdateTimeEntry": {
             "httpMethod": "PUT",
             "uri": "time_entries/{id}",


### PR DESCRIPTION
This PR adds support for the [current running time entry](https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md#get-running-time-entry). `GetTimeEntry` is limited to an integer `id` parameter so can't be used for this purpose.