### PR TITLE
Added new API calls for groups/users

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1050,6 +1050,19 @@
                 }
             }
         },
+        "GetGroups":{
+            "httpMethod": "GET",
+            "uri": "workspaces/{id}/groups",
+            "summary": "Get groups",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "description": "Workspace ID",
+                    "required": true,
+                    "type": "integer"
+                }
+            }
+        },
         "GetWorkspaces": {
             "httpMethod": "GET",
             "uri": "workspaces",
@@ -1058,6 +1071,19 @@
         "GetWorkspaceUsers": {
             "httpMethod": "GET",
             "uri": "workspaces/{id}/users",
+            "summary": "Get workspace users",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "description": "Workspace ID",
+                    "required": true,
+                    "type": "integer"
+                }
+            }
+        },
+        "GetWorkspaceWorkspaceUsers": {
+            "httpMethod": "GET",
+            "uri": "workspaces/{id}/workspace_users",
             "summary": "Get workspace users",
             "parameters": {
                 "id": {


### PR DESCRIPTION
Added new workspace users and workspace groups API calls. Information not documented in official Toggl API docs but provided via email support from them in the following email.

-- BEGIN TOGGL SUPPORT EMAIL --
Thanks for getting in touch with us.

You can get a list of all groups with their names and group IDs with a GET request to this endpoint: https://toggl.com/api/v8/workspaces/{workspace_id}/groups
Sending a GET request to https://toggl.com/api/v8/workspaces/{workspace_id}/workspace_users will give you a list of all users in the workspace, each user will have a property "group_ids" that is an array containing the IDs of the groups they are members of.
You will then have to collate the two on your end, this way you can create a list of the members of each group.

I let my colleagues know that this is missing from the documentation.

If you have any more questions, let me know, I'll be glad to answer them.
All the best,
-- 
Robert 

Toggl Support