### PR TITLE
fixed PHP fatal error of return context

### DIFF
--- a/src/AJT/Toggl/TogglClient.php
+++ b/src/AJT/Toggl/TogglClient.php
@@ -55,12 +55,12 @@ class TogglClient extends Client
             "Content-type" => "application/json",
         ));
 
-        if(!empty($config->get('api_key'))) {
+        if($config->get('api_key')) {
             $config->set('username', $config->get('api_key'));
             $config->set('password', 'api_token');
         }
 
-        if(empty($config->get('password'))) {
+        if(!$config->get('password')) {
             $config->set('password', 'api_token');
         }
         $authPlugin = new CurlAuthPlugin($config->get('username'), $config->get('password'));


### PR DESCRIPTION
because of empty check against function PHP throws FATAL
as soon as it includes the file
error message is
Can’t use method return value in write context
