### PR TITLE
Add additional Toggl v8 API functions

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1110,6 +1110,18 @@
                     "description": "possible values true/false/both. By default true. If false, only archived projects are returned.",
                     "type": "string",
                     "default": "true"
+                },
+                "actual_hours": {
+                    "location": "query",
+                    "description": "If true, the completed hours per project are returned.",
+                    "type": "string",
+                    "default": "false"
+                },
+                "only_templates": {
+                    "location": "query",
+                    "description": "If true, only the project templates are returned.",
+                    "type": "string",
+                    "default": "false"
                 }
             }
         },

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -108,6 +108,19 @@
                 }
             }
         },
+        "DeleteClients": {
+            "httpMethod": "DELETE",
+            "uri": "clients/{ids}",
+            "summary": "Delete multiple Clients",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "type": "string",
+                    "required": true,
+                    "description": "Comma separated list of Client IDs"
+                }
+            }
+        },
         "GetClients": {
             "httpMethod": "GET",
             "uri": "clients",
@@ -309,6 +322,19 @@
                     "type": "integer",
                     "required": true,
                     "description": "Project ID"
+                }
+            }
+        },
+        "DeleteProjects": {
+            "httpMethod": "DELETE",
+            "uri": "projects/{ids}",
+            "summary": "Delete multiple Project",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "type": "string",
+                    "required": true,
+                    "description": "Comma separated list of Project IDs"
                 }
             }
         },

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1145,6 +1145,19 @@
                 }
             }
         },
+        "GetWorkspaceProjectUsers": {
+            "httpMethod": "GET",
+            "uri": "workspaces/{id}/project_users",
+            "summary": "Get workspace project users",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "description": "Workspace ID",
+                    "required": true,
+                    "type": "integer"
+                }
+            }
+        },
         "UpdateWorkspaceUser": {
             "httpMethod": "PUT",
             "uri": "workspace_users/{id}",

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -113,7 +113,7 @@
             "uri": "clients/{ids}",
             "summary": "Delete multiple Clients",
             "parameters": {
-                "id": {
+                "ids": {
                     "location": "uri",
                     "type": "string",
                     "required": true,
@@ -330,7 +330,7 @@
             "uri": "projects/{ids}",
             "summary": "Delete multiple Project",
             "parameters": {
-                "id": {
+                "ids": {
                     "location": "uri",
                     "type": "string",
                     "required": true,

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -108,19 +108,6 @@
                 }
             }
         },
-        "DeleteClients": {
-            "httpMethod": "DELETE",
-            "uri": "clients/{ids}",
-            "summary": "Delete multiple Clients",
-            "parameters": {
-                "ids": {
-                    "location": "uri",
-                    "type": "string",
-                    "required": true,
-                    "description": "Comma separated list of Client IDs"
-                }
-            }
-        },
         "GetClients": {
             "httpMethod": "GET",
             "uri": "clients",

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1035,6 +1035,16 @@
                             "type": "string",
                             "required": true,
                             "description": "password at least 6 characters long (string, required)"
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "required": true,
+                            "description": "for example 'Etc/UTC' (string, required)"
+                        },
+                        "created_with": {
+                            "type": "string",
+                            "required": true,
+                            "description": "in free form, name of the app that signed the user app (string, required)"
                         }
                     }
                 }


### PR DESCRIPTION
The "delete a project" action on Toggl API supports multiple comma-separated Project ID numbers, so I added "DeleteProjects" to guzzle-toggl in a style similar to that used for other Toggl API objects.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md#delete-multiple-projects

I suggested to Toggl that the same method should be supported on Clients, but it's not, and they declined to implement but said it will be added on v9 of the API.

I asked Toggl to implement a means to query for all Project Users within a workspace, for sanity check purposes, and they responded by saying that exists but is not documented, then updated the docs. I have added a guzzle-toggl method 'GetWorkspaceProjectUsers' to take advantage of this. This has been tested and works.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md#get-list-of-project-users-in-a-workspace

In "GetWorkspaceProjects", I added some query parameters which I happened to notice in the docs but missing from guzzle-toggl. These were not tested but mirror the format used for other similar parameters.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md#get-workspace-projects

(Note: Sorry for direct blob links, however right now there's something wrong with GitHub and it's not mapping URLs from the project root properly. Anyone reading this in the future should take care to verify if links end up broken or something).