### PR TITLE
Add additional Toggl v8 API functions

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1110,6 +1110,18 @@
                     "description": "possible values true/false/both. By default true. If false, only archived projects are returned.",
                     "type": "string",
                     "default": "true"
+                },
+                "actual_hours": {
+                    "location": "query",
+                    "description": "If true, the completed hours per project are returned.",
+                    "type": "string",
+                    "default": "false"
+                },
+                "only_templates": {
+                    "location": "query",
+                    "description": "If true, only the project templates are returned.",
+                    "type": "string",
+                    "default": "false"
                 }
             }
         },

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -108,6 +108,19 @@
                 }
             }
         },
+        "DeleteClients": {
+            "httpMethod": "DELETE",
+            "uri": "clients/{ids}",
+            "summary": "Delete multiple Clients",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "type": "string",
+                    "required": true,
+                    "description": "Comma separated list of Client IDs"
+                }
+            }
+        },
         "GetClients": {
             "httpMethod": "GET",
             "uri": "clients",
@@ -309,6 +322,19 @@
                     "type": "integer",
                     "required": true,
                     "description": "Project ID"
+                }
+            }
+        },
+        "DeleteProjects": {
+            "httpMethod": "DELETE",
+            "uri": "projects/{ids}",
+            "summary": "Delete multiple Project",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "type": "string",
+                    "required": true,
+                    "description": "Comma separated list of Project IDs"
                 }
             }
         },

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1145,6 +1145,19 @@
                 }
             }
         },
+        "GetWorkspaceProjectUsers": {
+            "httpMethod": "GET",
+            "uri": "workspaces/{id}/project_users",
+            "summary": "Get workspace project users",
+            "parameters": {
+                "id": {
+                    "location": "uri",
+                    "description": "Workspace ID",
+                    "required": true,
+                    "type": "integer"
+                }
+            }
+        },
         "UpdateWorkspaceUser": {
             "httpMethod": "PUT",
             "uri": "workspace_users/{id}",

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -73,13 +73,8 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "required": true,
-                            "description": "The name of the client (string, required, unique in workspace)"
-                        },
-                        "wid": {
-                            "type": "integer",
-                            "required": true,
-                            "description": "workspace ID, where the client will be used (integer, required)"
+                            "required": false,
+                            "description": "The name of the client (string, not required, unique in workspace)"
                         },
                         "notes": {
                             "type": "string",
@@ -160,7 +155,7 @@
                         "cid": {
                             "type": "integer",
                             "required": false,
-                            "description": "client ID(integer, not required)"
+                            "description": "client ID (integer, not required)"
                         },
                         "active": {
                             "type": "boolean",
@@ -258,18 +253,18 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "required": true,
-                            "description": "The name of the project (string, required, unique for client and workspace)"
+                            "required": false,
+                            "description": "The name of the project (string, not required, unique for client and workspace)"
                         },
                         "wid": {
                             "type": "integer",
-                            "required": true,
-                            "description": "workspace ID, where the project will be saved (integer, required)"
+                            "required": false,
+                            "description": "workspace ID, where the project will be saved (integer, not required)"
                         },
                         "cid": {
                             "type": "integer",
                             "required": false,
-                            "description": "client ID(integer, not required)"
+                            "description": "client ID (integer, not required)"
                         },
                         "active": {
                             "type": "boolean",
@@ -391,21 +386,6 @@
                     "type": "object",
                     "description": "Project User Object",
                     "properties": {
-                        "pid": {
-                            "type": "integer",
-                            "required": true,
-                            "description": "project ID (integer, required)"
-                        },
-                        "uid": {
-                            "type": "integer",
-                            "required": true,
-                            "description": "user ID, who is added to the project (integer, required)"
-                        },
-                        "wid": {
-                            "type": "integer",
-                            "required": false,
-                            "description": "workspace ID, where the project belongs to (integer, not-required, project's workspace id is used)"
-                        },
                         "manager": {
                             "type": "boolean",
                             "required": false,
@@ -505,21 +485,6 @@
                         "type": "object",
                         "description": "Project User Object",
                         "properties": {
-                            "pid": {
-                                "type": "integer",
-                                "required": true,
-                                "description": "project ID (integer, required)"
-                            },
-                            "uid": {
-                                "type": "integer",
-                                "required": true,
-                                "description": "user ID, who is added to the project (integer, required)"
-                            },
-                            "wid": {
-                                "type": "integer",
-                                "required": false,
-                                "description": "workspace ID, where the project belongs to (integer, not-required, project's workspace id is used)"
-                            },
                             "manager": {
                                 "type": "boolean",
                                 "required": false,
@@ -598,11 +563,6 @@
                             "type": "string",
                             "required": true,
                             "description": "The name of the tag (string, required, unique in workspace)"
-                        },
-                        "wid": {
-                            "type": "integer",
-                            "required": true,
-                            "description": "workspace ID, where the tag will be used (integer, required). Workspace id (wid) can't be changed."
                         }
                     }
                 }
@@ -697,18 +657,8 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "required": true,
-                            "description": "The name of the task (string, required, unique in project)"
-                        },
-                        "pid": {
-                            "type": "integer",
-                            "required": true,
-                            "description": "project ID for the task (integer, required). Project id (pid) can't be changed on update."
-                        },
-                        "wid": {
-                            "type": "integer",
                             "required": false,
-                            "description": "workspace ID, where the task will be saved (integer, project's workspace id is used when not supplied). Workspace id (wid) can't be changed on update."
+                            "description": "The name of the task (string, not required, unique in project)"
                         },
                         "uid": {
                             "type": "integer",
@@ -763,18 +713,8 @@
                         "properties": {
                             "name": {
                                 "type": "string",
-                                "required": true,
-                                "description": "The name of the task (string, required, unique in project)"
-                            },
-                            "pid": {
-                                "type": "integer",
-                                "required": true,
-                                "description": "project ID for the task (integer, required). Project id (pid) can't be changed on update."
-                            },
-                            "wid": {
-                                "type": "integer",
                                 "required": false,
-                                "description": "workspace ID, where the task will be saved (integer, project's workspace id is used when not supplied). Workspace id (wid) can't be changed on update."
+                                "description": "The name of the task (string, not required, unique in project)"
                             },
                             "uid": {
                                 "type": "integer",
@@ -822,8 +762,8 @@
                     "properties": {
                         "description": {
                             "type": "string",
-                            "required": true,
-                            "description": "(string, required)"
+                            "required": false,
+                            "description": "(string, not required)"
                         },
                         "wid": {
                             "type": "integer",
@@ -832,7 +772,7 @@
                         },
                         "pid": {
                             "type": "integer",
-                            "required": true,
+                            "required": false,
                             "description": "pid: project ID (integer, not required)"
                         },
                         "tid": {
@@ -890,8 +830,8 @@
                     "properties": {
                         "description": {
                             "type": "string",
-                            "required": true,
-                            "description": "(string, required)"
+                            "required": false,
+                            "description": "(string, not required)"
                         },
                         "wid": {
                             "type": "integer",
@@ -900,7 +840,7 @@
                         },
                         "pid": {
                             "type": "integer",
-                            "required": true,
+                            "required": false,
                             "description": "pid: project ID (integer, not required)"
                         },
                         "tid": {
@@ -985,8 +925,8 @@
                     "properties": {
                         "description": {
                             "type": "string",
-                            "required": true,
-                            "description": "(string, required)"
+                            "required": false,
+                            "description": "(string, not required)"
                         },
                         "wid": {
                             "type": "integer",
@@ -1011,8 +951,8 @@
                         },
                         "created_with": {
                             "type": "string",
-                            "required": true,
-                            "description": "the name of your client app (string, required)"
+                            "required": false,
+                            "description": "the name of your client app (string, not required)"
                         },
                         "tags": {
                             "type": "array",
@@ -1024,8 +964,8 @@
                         },
                         "duration": {
                             "type": "integer",
-                            "required": true,
-                            "description": "duration of time entry (integer, required)"
+                            "required": false,
+                            "description": "duration of time entry (integer, not required)"
                         },
                         "duronly": {
                             "type": "boolean",
@@ -1034,8 +974,8 @@
                         },
                         "start": {
                             "type": "string",
-                            "required": true,
-                            "description": "start of time entry (string, required, ISO 8601 date and time)"
+                            "required": false,
+                            "description": "start of time entry (string, not required, ISO 8601 date and time)"
                         }
                     }
                 }

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -113,7 +113,7 @@
             "uri": "clients/{ids}",
             "summary": "Delete multiple Clients",
             "parameters": {
-                "id": {
+                "ids": {
                     "location": "uri",
                     "type": "string",
                     "required": true,
@@ -330,7 +330,7 @@
             "uri": "projects/{ids}",
             "summary": "Delete multiple Project",
             "parameters": {
-                "id": {
+                "ids": {
                     "location": "uri",
                     "type": "string",
                     "required": true,

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -108,19 +108,6 @@
                 }
             }
         },
-        "DeleteClients": {
-            "httpMethod": "DELETE",
-            "uri": "clients/{ids}",
-            "summary": "Delete multiple Clients",
-            "parameters": {
-                "ids": {
-                    "location": "uri",
-                    "type": "string",
-                    "required": true,
-                    "description": "Comma separated list of Client IDs"
-                }
-            }
-        },
         "GetClients": {
             "httpMethod": "GET",
             "uri": "clients",

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -1035,6 +1035,16 @@
                             "type": "string",
                             "required": true,
                             "description": "password at least 6 characters long (string, required)"
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "required": true,
+                            "description": "for example 'Etc/UTC' (string, required)"
+                        },
+                        "created_with": {
+                            "type": "string",
+                            "required": true,
+                            "description": "in free form, name of the app that signed the user app (string, required)"
                         }
                     }
                 }


### PR DESCRIPTION
(Note: This is a second PR for this content, with the previous merge conflict resolved.)

The "delete a project" action on Toggl API supports multiple comma-separated Project ID numbers, so I added "DeleteProjects" to guzzle-toggl in a style similar to that used for other Toggl API objects.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md#delete-multiple-projects

I suggested to Toggl that the same method should be supported on Clients, but it's not, and they declined to implement but said it will be added on v9 of the API.

I asked Toggl to implement a means to query for all Project Users within a workspace, for sanity check purposes, and they responded by saying that exists but is not documented, then updated the docs. I have added a guzzle-toggl method 'GetWorkspaceProjectUsers' to take advantage of this. This has been tested and works.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md#get-list-of-project-users-in-a-workspace

In "GetWorkspaceProjects", I added some query parameters which I happened to notice in the docs but missing from guzzle-toggl. These were not tested but mirror the format used for other similar parameters.
Docs reference: https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md#get-workspace-projects