### PR TITLE
Added response models where missing for Client requests

### DIFF
--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -8,6 +8,7 @@
       "httpMethod": "POST",
       "uri": "clients",
       "summary": "Create Client",
+      "responseModel": "getResponse",
       "parameters": {
         "client": {
           "location": "json",
@@ -47,6 +48,7 @@
       "httpMethod": "GET",
       "uri": "clients/{id}",
       "summary": "Get Client Details",
+      "responseModel": "getResponse",
       "parameters": {
         "id": {
           "location": "uri",
@@ -60,6 +62,7 @@
       "httpMethod": "PUT",
       "uri": "clients/{id}",
       "summary": "Update Client",
+      "responseModel": "getResponse",
       "parameters": {
         "id": {
           "location": "uri",
@@ -100,6 +103,7 @@
       "httpMethod": "DELETE",
       "uri": "clients/{id}",
       "summary": "Delete Client",
+      "responseModel": "getResponse",
       "parameters": {
         "id": {
           "location": "uri",


### PR DESCRIPTION
The missing response models cause Guzzle to return an empty body. Specifically, I was trying to create new Clients in Toggl, but was getting empty responses back, and therefore couldn't access the data of the newly created Client (Toggle client ID).