### PR TITLE
Update baseUri to new API endpoint

### DIFF
--- a/src/AJT/Toggl/reporting_v2.json
+++ b/src/AJT/Toggl/reporting_v2.json
@@ -2,7 +2,7 @@
   "name": "Toggl Reports",
   "apiVersion": "v2",
   "description": "Toggl Reports API v2",
-  "baseUri": "https://www.toggl.com/reports/api/v2/",
+  "baseUri": "https://api.track.toggl.com/reports/api/v2/",
   "operations": {
     "Weekly": {
       "httpMethod": "GET",

--- a/src/AJT/Toggl/services_v8.json
+++ b/src/AJT/Toggl/services_v8.json
@@ -2,7 +2,7 @@
   "name": "Toggl",
   "apiVersion": "v8",
   "description": "Toggl API v8",
-  "baseUri": "https://www.toggl.com/api/v8/",
+  "baseUri": "https://api.track.toggl.com/api/v8/",
   "operations": {
     "CreateClient": {
       "httpMethod": "POST",


### PR DESCRIPTION
Quick change of the endpoint baseUri used as Toggl will drop support for the legacy URL after June 30th 2021 ([https://toggl.com/blog/api-documentation-change](https://toggl.com/blog/api-documentation-change)).

Fix for Issue #29.

