### PR TITLE
Compatibility with V9 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Toggl API client based on Guzzle PHP
 
 ## Features
 
-* supports complete version 8 API with API Key authentication (thanks to @dirx)
+* supports partial version 9 API with API Key authentication (thanks to @edward-simpson)
 * supports Toggl Report Api v2 (thanks to @dirx)
 * now based on guzzle 7 
 
@@ -14,7 +14,7 @@ New releases will be based on guzzle7.
 
 ## Installation
 
-The library is available through Composer, so its easy to get it. 
+The library is available through Composer, so it's easy to get it. 
 Simply run this to install it:
 
     composer require ajt/guzzle-toggl
@@ -31,10 +31,10 @@ require __DIR__.'/../vendor/autoload.php';
 
 use AJT\Toggl\TogglClient;
 $toggl_token = ''; // Fill in your token here
-$toggl_client = TogglClient::factory(array('api_key' => $toggl_token));
+$toggl_client = TogglClient::factory(['api_key' => $toggl_token]);
 
 // if you want to see what is happening, add debug => true to the factory call
-$toggl_client = TogglClient::factory(array('api_key' => $toggl_token, 'debug' => true)); 
+$toggl_client = TogglClient::factory(['api_key' => $toggl_token, 'debug' => true]); 
 ```
 
 Invoke Commands using our `__call` method (auto-complete phpDocs are included)
@@ -42,9 +42,9 @@ Invoke Commands using our `__call` method (auto-complete phpDocs are included)
 ```php
 <?php 
 use AJT\Toggl\TogglClient;
-$toggl_client = TogglClient::factory(array('api_key' => $toggl_token));
+$toggl_client = TogglClient::factory(['api_key' => $toggl_token]);
 
-$workspaces = $toggl_client->getWorkspaces(array());
+$workspaces = $toggl_client->getWorkspaces([]);
 
 foreach($workspaces as $workspace){
 	$id = $workspace['id'];
@@ -57,10 +57,10 @@ Or Use the `getCommand` method (in this case you need to work with the $response
 ```php
 <?php 
 use AJT\Toggl\TogglClient;
-$toggl_client = TogglClient::factory(array('api_key' => $toggl_token));
+$toggl_client = TogglClient::factory(['api_key' => $toggl_token]);
 
 //Retrieve the Command from Guzzle
-$command = $toggl_client->getCommand('GetWorkspaces', array());
+$command = $toggl_client->getCommand('GetWorkspaces', []);
 $command->prepare();
 
 $response = $command->execute();
@@ -79,6 +79,60 @@ Afterwards you can execute the examples in the examples directory.
 
 You can look at the services.json for details on what methods are available and what parameters are available to call them
 
+## Migrating to v9
+Almost all the methods retain the same naming, but some parameters have changed.
+
+The following endpoints now require a `workspace_id` to be passed in the parameters:
+- CreateClient
+- GetClient
+- UpdateClient
+- DeleteClient
+- CreateProject
+- GetProject
+- UpdateProject
+- CreateProjectUser
+- CreateProjectUsers
+- UpdateProjectUser
+- UpdateProjectUsers
+- DeleteProjectUser
+- DeleteProjectUsers
+- CreateTag
+- UpdateTag
+- DeleteTag
+- CreateTask (also requires a `project_id`)
+- GetTask (also requires a `project_id`)
+- UpdateTask (also requires a `project_id`)
+- UpdateTasks (also requires a `project_id`)
+- DeleteTask (also requires a `project_id`)
+- DeleteTasks (also requires a `project_id`)
+- StartTimeEntry
+- StopTimeEntry
+- UpdateTimeEntry
+- DeleteTimeEntry
+
+The following endpoints now require a `project_id` to be passed in the parameters:
+- CreateTask
+- GetTask
+- UpdateTask
+- UpdateTasks
+- DeleteTask
+- DeleteTasks
+
+The following endpoints are new:
+- ArchiveClient
+- RestoreClient
+
+The following endpoints have changed their parameters:
+- GetProjects (`id` is now `workspace_id`, for clarity)
+- GetProjectUsers no longer accepts a `project_id` parameter, but instead accepts a `workspace_id` parameter
+
+The following endpoints have had their name changed, to match the toggl docs more closely:
+- InviteWorkspaceUser -> InviteOrganizationUser
+
+The following endpoints have been removed:
+- GetWorkspaceWorkspaceUsers
+- GetWorkspaceProjects (use GetProjects instead)
+
 ## Todo
 
 - [ ] Add some more examples
@@ -88,7 +142,7 @@ You can look at the services.json for details on what methods are available and 
 ## Contributions welcome
 
 Found a bug, open an issue, preferably with the debug output and what you did. 
-Bugfix? Open a Pull Request and i'll look into it. 
+Bugfix? Open a Pull Request and I'll look into it. 
 
 ## License
 

--- a/apikey-dist.php
+++ b/apikey-dist.php
@@ -8,7 +8,7 @@
  * @var string
  */
 $toggl_api_key = '';
-$toggl_api_version = 'v8';
+$toggl_api_version = 'v9';
 $toggle_api_reporting_version = 'v2';
 
 $username = 'mail@example.com';

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["toggl", "ajt", "api", "guzzle"],
     "homepage": "http://github.com/arendjantetteroo/guzzle-toggl",
     "license": "MIT",
+    "version": "9.0.0",
     "authors": [
         {
             "name": "Arend-Jan Tetteroo",

--- a/src/AJT/Toggl/TogglClient.php
+++ b/src/AJT/Toggl/TogglClient.php
@@ -32,11 +32,11 @@ class TogglClient extends GuzzleClient
     {
         $guzzleClient = new Client(self::getClientConfig($config));
 
-        if (isset($config['apiVersion']) && $config['apiVersion'] !== 'v8') {
-            throw new InvalidApiVersionException('Only v8 is supported at this time');
+        if (isset($config['apiVersion']) && $config['apiVersion'] !== 'v9') {
+            throw new InvalidApiVersionException('Only v9 is supported at this time');
         }
 
-        return new self($guzzleClient, self::getAPIDescriptionByJsonFile('services_v8.json'));
+        return new self($guzzleClient, self::getAPIDescriptionByJsonFile('services_v9.json'));
     }
 
     protected static function getAPIDescriptionByJsonFile($file): Description

--- a/src/AJT/Toggl/services_v9.json
+++ b/src/AJT/Toggl/services_v9.json
@@ -1,15 +1,21 @@
 {
   "name": "Toggl",
-  "apiVersion": "v8",
-  "description": "Toggl API v8",
-  "baseUri": "https://api.track.toggl.com/api/v8/",
+  "apiVersion": "v9",
+  "description": "Toggl API v9",
+  "baseUri": "https://api.track.toggl.com/api/v9/",
   "operations": {
     "CreateClient": {
       "httpMethod": "POST",
-      "uri": "clients",
+      "uri": "workspaces/{workspace_id}/clients",
       "summary": "Create Client",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "client": {
           "location": "json",
           "type": "object",
@@ -46,10 +52,16 @@
     },
     "GetClient": {
       "httpMethod": "GET",
-      "uri": "clients/{id}",
+      "uri": "workspaces/{workspace_id}/clients/{id}",
       "summary": "Get Client Details",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -60,10 +72,16 @@
     },
     "UpdateClient": {
       "httpMethod": "PUT",
-      "uri": "clients/{id}",
+      "uri": "workspaces/{workspace_id}/clients/{id}",
       "summary": "Update Client",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -101,10 +119,56 @@
     },
     "DeleteClient": {
       "httpMethod": "DELETE",
-      "uri": "clients/{id}",
+      "uri": "workspaces/{workspace_id}/clients/{id}",
       "summary": "Delete Client",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
+        "id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Client ID"
+        }
+      }
+    },
+    "ArchiveClient": {
+      "httpMethod": "POST",
+      "uri": "workspaces/{workspace_id}/clients/{id}/archive",
+      "summary": "Archive Client",
+      "responseModel": "getResponse",
+      "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
+        "id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Client ID"
+        }
+      }
+    },
+    "RestoreClient": {
+      "httpMethod": "DELETE",
+      "uri": "workspaces/{workspace_id}/clients/{id}/restore",
+      "summary": "Restore Archived Client",
+      "responseModel": "getResponse",
+      "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -115,7 +179,7 @@
     },
     "GetClients": {
       "httpMethod": "GET",
-      "uri": "clients",
+      "uri": "me/clients",
       "summary": "Get clients visible to user",
       "responseModel": "getResponse"
     },
@@ -141,10 +205,16 @@
     },
     "CreateProject": {
       "httpMethod": "POST",
-      "uri": "projects",
+      "uri": "workspaces/{workspace_id}/projects",
       "summary": "Create Project",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "project": {
           "location": "json",
           "type": "object",
@@ -200,11 +270,11 @@
     },
     "GetProjects": {
       "httpMethod": "GET",
-      "uri": "workspaces/{id}/projects",
+      "uri": "workspaces/{workspace_id}/projects",
       "summary": "Get projects",
       "responseModel": "getResponse",
       "parameters": {
-        "id": {
+        "workspace_id": {
           "location": "uri",
           "description": "Workspace ID",
           "required": true,
@@ -220,10 +290,16 @@
     },
     "GetProject": {
       "httpMethod": "GET",
-      "uri": "projects/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{id}",
       "summary": "Get Project details",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -248,10 +324,16 @@
     },
     "UpdateProject": {
       "httpMethod": "PUT",
-      "uri": "projects/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{id}",
       "summary": "Update Project",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -313,10 +395,16 @@
     },
     "DeleteProject": {
       "httpMethod": "DELETE",
-      "uri": "projects/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{id}",
       "summary": "Delete Project",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "type": "integer",
+          "required": true,
+          "description": "Workspace ID"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -341,13 +429,13 @@
     },
     "GetProjectUsers": {
       "httpMethod": "GET",
-      "uri": "projects/{id}/project_users",
+      "uri": "workspaces/{workspace_id}/project_users",
       "summary": "Get project users",
       "responseModel": "getResponse",
       "parameters": {
-        "id": {
+        "workspace_id": {
           "location": "uri",
-          "description": "Project ID",
+          "description": "Workspace ID",
           "required": true,
           "type": "integer"
         }
@@ -355,10 +443,16 @@
     },
     "CreateProjectUser": {
       "httpMethod": "POST",
-      "uri": "project_users",
+      "uri": "workspaces/{workspace_id}/project_users",
       "summary": "Create Project User",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "project_user": {
           "location": "json",
           "type": "object",
@@ -401,10 +495,16 @@
     },
     "UpdateProjectUser": {
       "httpMethod": "PUT",
-      "uri": "project_users/{id}",
+      "uri": "workspaces/{workspace_id}/project_users/{id}",
       "summary": "Update Project User",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -438,10 +538,16 @@
     },
     "DeleteProjectUser": {
       "httpMethod": "DELETE",
-      "uri": "project_users/{id}",
+      "uri": "workspaces/{workspace_id}/project_users/{id}",
       "summary": "Delete Project User",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -452,10 +558,16 @@
     },
     "CreateProjectUsers": {
       "httpMethod": "POST",
-      "uri": "project_users",
+      "uri": "workspaces/{workspace_id}/project_users",
       "summary": "Create multiple Project Users",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "project_user": {
           "location": "json",
           "type": "array",
@@ -501,10 +613,16 @@
     },
     "UpdateProjectUsers": {
       "httpMethod": "PUT",
-      "uri": "project_users/{ids}",
+      "uri": "workspaces/{workspace_id}/project_users/{ids}",
       "summary": "Update multiple Project User",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "ids": {
           "location": "uri",
           "type": "string",
@@ -541,10 +659,16 @@
     },
     "DeleteProjectUsers": {
       "httpMethod": "DELETE",
-      "uri": "project_users/{ids}",
+      "uri": "workspaces/{workspace_id}/project_users/{ids}",
       "summary": "Delete multiple Project Users",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "ids": {
           "location": "uri",
           "type": "string",
@@ -555,10 +679,16 @@
     },
     "CreateTag": {
       "httpMethod": "POST",
-      "uri": "tags",
+      "uri": "workspaces/{workspace_id}/tags",
       "summary": "Create Tag",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "tag": {
           "location": "json",
           "type": "object",
@@ -580,10 +710,16 @@
     },
     "UpdateTag": {
       "httpMethod": "PUT",
-      "uri": "tags/{id}",
+      "uri": "workspaces/{workspace_id}/tags/{id}",
       "summary": "Update Tag",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -606,10 +742,16 @@
     },
     "DeleteTag": {
       "httpMethod": "DELETE",
-      "uri": "tags/{id}",
+      "uri": "workspaces/{workspace_id}/tags/{id}",
       "summary": "Delete Tag",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -620,10 +762,22 @@
     },
     "CreateTask": {
       "httpMethod": "POST",
-      "uri": "tasks",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks",
       "summary": "Create Task",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "task": {
           "location": "json",
           "type": "object",
@@ -666,10 +820,22 @@
     },
     "GetTask": {
       "httpMethod": "GET",
-      "uri": "tasks/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks/{id}",
       "summary": "Get Task",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -680,10 +846,22 @@
     },
     "UpdateTask": {
       "httpMethod": "PUT",
-      "uri": "tasks/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks/{id}",
       "summary": "Update Task",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -722,10 +900,22 @@
     },
     "DeleteTask": {
       "httpMethod": "DELETE",
-      "uri": "tasks/{id}",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks/{id}",
       "summary": "Delete Task",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -736,10 +926,22 @@
     },
     "UpdateTasks": {
       "httpMethod": "PUT",
-      "uri": "tasks/{ids}",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks/{ids}",
       "summary": "Update Tasks",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "ids": {
           "location": "uri",
           "type": "string",
@@ -781,10 +983,22 @@
     },
     "DeleteTasks": {
       "httpMethod": "DELETE",
-      "uri": "tasks/{ids}",
+      "uri": "workspaces/{workspace_id}/projects/{project_id}/tasks/{ids}",
       "summary": "Delete Tasks",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
+        "project_id": {
+          "location": "uri",
+          "description": "Project ID",
+          "required": true,
+          "type": "integer"
+        },
         "ids": {
           "location": "uri",
           "type": "string",
@@ -864,15 +1078,27 @@
     },
     "StartTimeEntry": {
       "httpMethod": "POST",
-      "uri": "time_entries/start",
+      "uri": "/workspaces/{workspace_id}/time_entries",
       "summary": "Start Time Entry",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "time_entry": {
           "location": "json",
           "type": "object",
           "description": "Time Entry Object",
           "properties": {
+            "duration": {
+              "type": "integer",
+              "static": true,
+              "description": "Negative value required to start time entry",
+              "default": -1
+            },
             "description": {
               "type": "string",
               "required": false,
@@ -922,11 +1148,17 @@
       }
     },
     "StopTimeEntry": {
-      "httpMethod": "PUT",
-      "uri": "time_entries/{id}/stop",
+      "httpMethod": "PATCH",
+      "uri": "workspaces/{workspace_id}/time_entries/{id}/stop",
       "summary": "Stop Time Entry",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -937,7 +1169,7 @@
     },
     "GetTimeEntry": {
       "httpMethod": "GET",
-      "uri": "time_entries/{id}",
+      "uri": "me/time_entries/{id}",
       "summary": "Get Time Entry",
       "responseModel": "getResponse",
       "parameters": {
@@ -951,15 +1183,21 @@
     },
     "GetCurrentTimeEntry": {
       "httpMethod": "GET",
-      "uri": "time_entries/current",
+      "uri": "me/time_entries/current",
       "summary": "Get Current Time Entry"
     },
     "UpdateTimeEntry": {
       "httpMethod": "PUT",
-      "uri": "time_entries/{id}",
+      "uri": "workspaces/{workspace_id}/time_entries/{id}",
       "summary": "Update Time Entry",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -1031,10 +1269,16 @@
     },
     "DeleteTimeEntry": {
       "httpMethod": "DELETE",
-      "uri": "time_entries/{id}",
+      "uri": "workspaces/{workspace_id}/time_entries/{id}",
       "summary": "Delete Time Entry",
       "responseModel": "getResponse",
       "parameters": {
+        "workspace_id": {
+          "location": "uri",
+          "description": "Workspace ID",
+          "required": true,
+          "type": "integer"
+        },
         "id": {
           "location": "uri",
           "type": "integer",
@@ -1045,7 +1289,7 @@
     },
     "GetTimeEntries": {
       "httpMethod": "GET",
-      "uri": "time_entries",
+      "uri": "me/time_entries",
       "summary": "Get time entries started in a specific time range.If start_date and end_date are not specified, time entries started during the last 9 days are returned.",
       "responseModel": "getResponse",
       "parameters": {
@@ -1069,7 +1313,7 @@
     },
     "CreateUser": {
       "httpMethod": "POST",
-      "uri": "signups",
+      "uri": "signup",
       "summary": "Sign up new user",
       "responseModel": "getResponse",
       "parameters": {
@@ -1104,11 +1348,11 @@
     },
     "GetGroups": {
       "httpMethod": "GET",
-      "uri": "workspaces/{id}/groups",
+      "uri": "workspaces/{workspace_id}/groups",
       "summary": "Get groups",
       "responseModel": "getResponse",
       "parameters": {
-        "id": {
+        "workspace_id": {
           "location": "uri",
           "description": "Workspace ID",
           "required": true,
@@ -1120,27 +1364,12 @@
       "httpMethod": "GET",
       "uri": "workspaces",
       "summary": "Get workspaces",
-      "responseModel": "getResponse",
       "responseModel": "getResponse"
     },
     "GetWorkspaceUsers": {
       "httpMethod": "GET",
       "uri": "workspaces/{id}/users",
       "summary": "Get workspace users",
-      "responseModel": "getResponse",
-      "parameters": {
-        "id": {
-          "location": "uri",
-          "description": "Workspace ID",
-          "required": true,
-          "type": "integer"
-        }
-      }
-    },
-    "GetWorkspaceWorkspaceUsers": {
-      "httpMethod": "GET",
-      "uri": "workspaces/{id}/workspace_users",
-      "summary": "Many-to-many middle object containing information about a specific user's access in the specific workspace",
       "responseModel": "getResponse",
       "parameters": {
         "id": {
@@ -1162,38 +1391,6 @@
           "description": "Workspace ID",
           "required": true,
           "type": "integer"
-        }
-      }
-    },
-    "GetWorkspaceProjects": {
-      "httpMethod": "GET",
-      "uri": "workspaces/{id}/projects",
-      "summary": "Get workspace projects",
-      "responseModel": "getResponse",
-      "parameters": {
-        "id": {
-          "location": "uri",
-          "description": "Workspace ID",
-          "required": true,
-          "type": "integer"
-        },
-        "active": {
-          "location": "query",
-          "description": "possible values true/false/both. By default true. If false, only archived projects are returned.",
-          "type": "string",
-          "default": "true"
-        },
-        "actual_hours": {
-          "location": "query",
-          "description": "If true, the completed hours per project are returned.",
-          "type": "string",
-          "default": "false"
-        },
-        "only_templates": {
-          "location": "query",
-          "description": "If true, only the project templates are returned.",
-          "type": "string",
-          "default": "false"
         }
       }
     },
@@ -1231,17 +1428,17 @@
         }
       }
     },
-    "InviteWorkspaceUser": {
+    "InviteOrganizationUser": {
       "httpMethod": "POST",
-      "uri": "workspaces/{id}/invite",
-      "summary": "Invite User to Workspace",
+      "uri": "organizations/{organization_id}/invitations",
+      "summary": "Invite User to Organization",
       "responseModel": "getResponse",
       "parameters": {
-        "id": {
+        "organization_id": {
           "location": "uri",
           "type": "integer",
           "required": true,
-          "description": "Workspace ID"
+          "description": "Organization ID"
         },
         "emails": {
           "location": "json",


### PR DESCRIPTION
Closes #43 

Majority of work to migrate over to the v9 API, but because of Toggl's silly format for migration notes, some of the changes to endpoints actually create duplicate endpoints (because of the changes to include `/workspace/{workspace_id}`, so I need to go through and de-dupe when I have time).

Creating as a draft pull request until I have time to finalise, but if anyone else wants to jump in in the mean time feel free