### PR TITLE
chore: update to a more recent guzzle-description-loader #37

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/guzzle-services": "^1.2",
-        "gimler/guzzle-description-loader": "^0.0.4"
+        "inveniem/guzzle-description-loader": "v1.0.0"
     },
     "autoload": {
         "psr-0": {"AJT": "src/"}


### PR DESCRIPTION
This new version allows sf 4,5 and 6 deps. A PR for 7 is submitted there. 

Closes #37